### PR TITLE
tvnow/dvbteeserver: fix error: redeclaration of ‘dvbtee_context tmpCo…

### DIFF
--- a/dvbteeserver.cpp
+++ b/dvbteeserver.cpp
@@ -653,9 +653,6 @@ extern "C" void dvbtee_start(void* nothing)
 #if TVNOW_TESTDATA
 	load_test_data();
 #else
-	dvbtee_context tmpContext;
-	context = &tmpContext;
-	context->server = NULL;
 
 #if 1 /* FIXME */
 	ATSCMultipleStringsInit();


### PR DESCRIPTION
tvnow/dvbteeserver: fix error: redeclaration of ‘dvbtee_context tmpContext’

```
make
g++ -I./libdvbtee/usr/include -I./libdvbtee/libdvbtee -I./libdvbtee/libdvbtee_server -Wno-deprecated -Wno-deprecated-declarations -pthread -fPIC -D_DEBUG -D_VERBOSE -g -ggdb -D_POSIX -D_GNU_SOURCE -D__USE_LARGEFILE64 -D__STDC_FORMAT_MACROS -D_FILE_OFFSET_BITS=64 -c dvbteeserver.cpp
dvbteeserver.cpp: In function ‘void dvbtee_start(void*)’:
dvbteeserver.cpp:656:17: error: redeclaration of ‘dvbtee_context tmpContext’
  dvbtee_context tmpContext;
                 ^
dvbteeserver.cpp:641:17: error: ‘dvbtee_context tmpContext’ previously declared here
  dvbtee_context tmpContext;
                 ^
make: *** [dvbteeserver] Error 1
```

fixes #7
