### PR TITLE
tv-now fixes & updates against libdvbtee 0.4.4

### DIFF
--- a/dvbteeserver.cpp
+++ b/dvbteeserver.cpp
@@ -601,12 +601,12 @@ bool list_channels(serve *server)
 	return server->get_channels(&iface);
 }
 
-bool start_async_channel_scan(serve *server, unsigned int flags = 0)
+void start_async_channel_scan(serve *server, unsigned int flags = 0)
 {
 	server->scan(flags);
 }
 
-bool channel_scan_and_dump(serve *server, unsigned int flags = 0)
+void channel_scan_and_dump(serve *server, unsigned int flags = 0)
 {
 	server_parse_iface iface;
 

--- a/dvbteeserver.cpp
+++ b/dvbteeserver.cpp
@@ -67,8 +67,6 @@
 #endif
 #include "serve.h"
 
-#include "atsctext.h"
-
 struct dvbtee_context
 {
 #if LINUXTV
@@ -167,9 +165,6 @@ void cleanup(struct dvbtee_context* context, bool quick = false)
 	}
 
 	context->tuner.close_fe();
-#if 1 /* FIXME */
-	ATSCMultipleStringsDeInit();
-#endif
 }
 
 void destroy_lists()
@@ -691,9 +686,6 @@ extern "C" void dvbtee_start(void* nothing)
 	unsigned int serv_flags  = 0;
 	unsigned int scan_flags  = 0;
 
-#if 1 /* FIXME */
-	ATSCMultipleStringsInit();
-#endif
 	context->tuner.feeder.parser.limit_eit(-1);
 //	enum output_options oopt = OUTPUT_PSIP;
 //	context->tuner.feeder.parser.out.set_options(oopt);
@@ -716,9 +708,6 @@ extern "C" void dvbtee_start(void* nothing)
 	}
 
 	//	cleanup(&context);
-	#if 1 /* FIXME */
-		ATSCMultipleStringsDeInit();
-	#endif
 #endif
 
 }


### PR DESCRIPTION
```
  dvbteeserver: remove ATSCMultipleStrings state handling as it is no longer needed
  dvbteeserver: fix warning: control reaches end of non-void function
```
